### PR TITLE
[231052] Bump up to 0.2.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule AntikytheraAws.MixProject do
   def project() do
     [
       app: :antikythera_aws,
-      version: "0.2.1",
+      version: "0.2.2",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/231052

I need to bump up the version to apply https://github.com/access-company/antikythera_aws/commit/6e1aca23093d7519f962db5fdae7eaff91b9b666 to our instances.

I'll merge this without review because this just changes the version number.